### PR TITLE
moved styles.css call to after bootsrap css, added rx-table class

### DIFF
--- a/frontend/index.php
+++ b/frontend/index.php
@@ -3,7 +3,6 @@
 <head>
     <title>ReactionRX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="css/styles.css" rel="stylesheet" media="screen">
     <link href="css/bootstrap.min.css" rel="stylesheet" media="screen">   
     <link href="css/jquery-ui.min-1.9.2.css" rel="stylesheet" media="screen">
     <link href="css/autocomplete-deluxe.css" rel="stylesheet" media="screen">
@@ -22,6 +21,9 @@
     <script src="js/autocomplete-deluxe.js"></script>
     <script src="js/autocomplete.js"></script>
     <script src="js/general.js"></script>
+
+    <link href="css/styles.css" rel="stylesheet" media="screen">
+
    <!-- google chart -->
     <script type="text/javascript" src="https://www.google.com/jsapi"></script>
     <!-- google chart end -->
@@ -70,8 +72,8 @@
 		              </div>
 		          </div>
 	              <div id="drug_table_div" class="table-responsive table-bordered table-stripped">          
-	                  <table class="table" id="drug_table"></table>
-	              </div>    
+	                  <table class="table rx-table" id="drug_table"></table>
+	              </div>
                   <div id="drug_stat_div"></div>
 			      <div id="btnDiv" ng-controller="btnController" class="ng-scope">
 	                  </br>       	
@@ -92,7 +94,7 @@
 	              </div>              
        
 	              <div id="reaction_table_div" class="table-responsive table-bordered table-stripped">          
-	                  <table class="table" id="reaction_table"></table>
+	                  <table class="table rx-table" id="reaction_table"></table>
 	              </div>
             
                   <div id="drug-info" class="container"></div>


### PR DESCRIPTION
This is so Bootstrap's default styles don't override the customizations in styles.less / styles.css, and the rx-table class is for further customization of the drug and reaction tables. 
