### PR TITLE
#16733. Google Chart with Two or More Drugs or Reactions - In the "Op…

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -245,6 +245,7 @@ header h1 a:hover {
   background-color: #154898;
   color: #fff;
   padding: 5px;
+  margin-right: -2px;
   border-radius: 0 0 8px 8px;
   box-shadow: 0px 0px 10px #888888;
 }
@@ -312,4 +313,18 @@ header h1 a:hover {
 }
 #reaction_stat_div.ui-dialog-content {
   overflow: hidden;
+}
+.nav-pills-justified {
+  width: 100%;
+}
+.nav-pills-justified > li {
+  display: table-cell;
+  width: 1%;
+  float: none;
+}
+.nav-pills-justified > li:first-child {
+  padding-right: 1px !important;
+}
+.nav-pills-justified > li:last-child {
+  padding-left: 1px !important;
 }

--- a/frontend/data/OpenFdaDataRetrieval.php
+++ b/frontend/data/OpenFdaDataRetrieval.php
@@ -16,7 +16,7 @@ $type = strip_tags($type);
 $type = htmlspecialchars($type);
 $keyword = strip_tags($keyword);
 $keyword = htmlspecialchars($keyword);
-$keyword = urlencode($keyword);
+$keyword = rawurlencode($keyword);
 
 if($type == "reaction") {
 	$url = API_SERVICE_BASE_URL . API_KEY . '/search/reaction/' . $keyword;

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -61,9 +61,9 @@
       
       <div class="col-md-6">
       
-          <ul class="nav nav-pills">
-		      <li class="active text-center" style="width:50%;"><a id="drugTab" data-toggle="pill" href="#search-drug">DRUG</a></li>
-		      <li class="text-center" style="width:49%;"><a id="reactionTab" data-toggle="pill" href="#search-reaction">ADVERSE REACTION</a></li>
+          <ul class="nav nav-pills nav-pills-justified">
+		      <li class="active text-center"><a id="drugTab" data-toggle="pill" href="#search-drug">DRUG</a></li>
+		      <li class="text-center"><a id="reactionTab" data-toggle="pill" href="#search-reaction">ADVERSE REACTION</a></li>
 		  </ul>
 		  
 		  <div id="drug-reaction-tab-container" class="tab-content gradient-drug-search">

--- a/frontend/less/styles.less
+++ b/frontend/less/styles.less
@@ -284,6 +284,7 @@ header h1 a:hover{
     background-color:#154898;
     color:#fff;
     padding:5px;
+    margin-right: -2px;
     border-radius: 0 0 8px 8px;
     box-shadow: 0px 0px 10px #888888;
 }
@@ -359,4 +360,22 @@ header h1 a:hover{
 
 #reaction_stat_div.ui-dialog-content {
 	overflow:hidden;
+}
+
+.nav-pills-justified {
+    width: 100%;
+}
+
+.nav-pills-justified>li {
+    display: table-cell;
+    width: 1%;
+    float:none;
+}
+
+.nav-pills-justified>li:first-child {
+    padding-right: 1px !important;
+}
+
+.nav-pills-justified>li:last-child {
+    padding-left: 1px !important;
 }


### PR DESCRIPTION
…enFdaDataRetrieval.php", I changed the function call from urlencode to rawurlencode. I did this because the urlencode function was changing "spaces" into "+" signs. The rawurlencode function changed "spaces" to "%20" which is what I needed in the URL to get the correct information from the API service; #16735. The "Drug" Tab and the "Reaction" Tab Do Not Line Up Correctly - I created a new class called "nav-pills-justified" that works similarly to the "nav-justified" bootstrap class except that the tabs do not get stacked when the resolution is less than 768px. The new class exists in the styles.css file.